### PR TITLE
feat: automate GitHub release publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Website for Gammu and Wammu, running at <https://wammu.eu/>.
 [![Code Health](https://landscape.io/github/gammu/website/master/landscape.svg?style=flat)](https://landscape.io/github/gammu/website/master)
 [![Build Status](https://travis-ci.org/gammu/website.svg?branch=master)](https://travis-ci.org/gammu/website)
 [![codecov](https://codecov.io/gh/gammu/website/branch/master/graph/badge.svg)](https://codecov.io/gh/gammu/website)
+
+## Release synchronization
+
+Run `./manage.py sync_github_releases` from cron to import new stable Gammu,
+python-gammu, and Wammu releases from GitHub. The command can use an optional
+`GITHUB_TOKEN` environment variable to increase the GitHub API rate limit.
+
+The synchronization backfills missing releases and does not update releases
+that are already present on the website.

--- a/downloads/management/commands/sync_github_releases.py
+++ b/downloads/management/commands/sync_github_releases.py
@@ -1,0 +1,251 @@
+import json
+import os
+import re
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils.dateparse import parse_datetime
+
+from downloads.models import Download, Release, get_program
+
+REPOSITORIES = {
+    "gammu": "gammu",
+    "python-gammu": "python-gammu",
+    "wammu": "wammu",
+}
+SYNC_USERNAME = "github-release-sync"
+SYNC_NAME = "Gammu release automation"
+VERSION_RE = re.compile(r"\d+(?:\.\d+)+\Z")
+WINDOWS_WHEEL_RE = re.compile(r"-win(?:32|_amd64|_arm64)\.whl\Z", re.IGNORECASE)
+SOURCE_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst", ".zip")
+WINDOWS_ZIP_MARKERS = ("windows", "win32", "win64", "win_amd64", "win_arm64")
+
+
+class Command(BaseCommand):
+    help = "imports new stable Gammu project releases from GitHub"
+
+    def handle(self, *args, **options):
+        releases_by_program = {
+            program: self.fetch_releases(repository)
+            for program, repository in REPOSITORIES.items()
+        }
+
+        created_releases = 0
+        created_downloads = 0
+        skipped_releases = 0
+
+        with transaction.atomic():
+            author = self.get_sync_user()
+
+            for program, github_releases in releases_by_program.items():
+                for github_release in reversed(github_releases):
+                    result = self.import_release(program, author, github_release)
+                    if result is None:
+                        skipped_releases += 1
+                        continue
+                    created_releases += 1
+                    created_downloads += result
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Created {created_releases} releases and "
+                f"{created_downloads} downloads; skipped "
+                f"{skipped_releases} releases.",
+            ),
+        )
+
+    def fetch_releases(self, repository):
+        url = f"https://api.github.com/repos/gammu/{repository}/releases?per_page=100"
+        releases = []
+
+        while url:
+            self.validate_api_url(url)
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "wammu.eu-release-sync",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+            token = os.environ.get("GITHUB_TOKEN")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
+            request = Request(url, headers=headers)
+            try:
+                with urlopen(request, timeout=30) as response:  # noqa: S310
+                    payload = json.loads(response.read())
+                    link_header = response.headers.get("Link", "")
+            except (HTTPError, URLError, OSError, json.JSONDecodeError) as error:
+                raise CommandError(
+                    f"Could not fetch releases for gammu/{repository}: {error}",
+                ) from error
+
+            if not isinstance(payload, list):
+                raise CommandError(
+                    f"Unexpected releases response for gammu/{repository}.",
+                )
+
+            releases.extend(payload)
+            url = self.get_next_url(link_header)
+
+        return releases
+
+    @staticmethod
+    def validate_api_url(url):
+        parsed = urlparse(url)
+        if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+            raise CommandError(f"Unexpected GitHub API pagination URL: {url}")
+
+    @staticmethod
+    def get_next_url(link_header):
+        for link in link_header.split(","):
+            target, separator, parameters = link.strip().partition(";")
+            if (
+                separator
+                and 'rel="next"' in parameters
+                and target.startswith("<")
+                and target.endswith(">")
+            ):
+                return target[1:-1]
+        return None
+
+    @staticmethod
+    def get_sync_user():
+        user, created = User.objects.get_or_create(
+            username=SYNC_USERNAME,
+            defaults={
+                "email": settings.SERVER_EMAIL,
+                "first_name": SYNC_NAME,
+                "is_active": False,
+            },
+        )
+        update_fields = []
+        if created:
+            user.set_unusable_password()
+            update_fields.append("password")
+        if not user.first_name:
+            user.first_name = SYNC_NAME
+            update_fields.append("first_name")
+        if not user.email:
+            user.email = settings.SERVER_EMAIL
+            update_fields.append("email")
+        if update_fields:
+            user.save(update_fields=update_fields)
+        return user
+
+    def import_release(self, program, author, github_release):
+        if not isinstance(github_release, dict):
+            raise CommandError(f"Unexpected release data for {program}.")
+
+        if github_release.get("draft") or github_release.get("prerelease"):
+            return None
+
+        version = github_release.get("tag_name")
+        if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+            self.stderr.write(
+                self.style.WARNING(
+                    f"Skipping {program} release with unsupported tag {version!r}.",
+                ),
+            )
+            return None
+
+        if Release.objects.filter(program=program, version=version).exists():
+            return None
+
+        published_at = github_release.get("published_at")
+        if not isinstance(published_at, str):
+            raise CommandError(f"Release {program} {version} has no publication date.")
+        release_date = parse_datetime(published_at)
+        if release_date is None:
+            raise CommandError(
+                f"Release {program} {version} has an invalid publication date.",
+            )
+
+        changelog = github_release.get("body") or ""
+        if not isinstance(changelog, str):
+            raise CommandError(f"Release {program} {version} has invalid notes.")
+
+        assets = github_release.get("assets")
+        if not isinstance(assets, list):
+            raise CommandError(f"Release {program} {version} has invalid assets.")
+
+        downloads = []
+        for asset in assets:
+            platform = self.get_asset_platform(asset)
+            if platform is not None:
+                downloads.append((asset, platform))
+
+        if not downloads:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"Skipping {program} {version} because it has "
+                    "no supported downloads.",
+                ),
+            )
+            return None
+
+        release = Release.objects.create(
+            author=author,
+            program=program,
+            version=version,
+            description="This release is available from GitHub.",
+            changelog=changelog.strip(),
+            date=release_date,
+        )
+
+        for asset, platform in downloads:
+            self.create_download(release, platform, asset)
+
+        self.stdout.write(
+            f"Imported {get_program(program)} {version} "
+            f"with {len(downloads)} downloads.",
+        )
+        return len(downloads)
+
+    @staticmethod
+    def get_asset_platform(asset):
+        if not isinstance(asset, dict):
+            raise CommandError("Unexpected GitHub release asset data.")
+
+        name = asset.get("name")
+        if not isinstance(name, str):
+            raise CommandError("GitHub release asset has no name.")
+
+        name_lower = name.lower()
+        if name_lower.endswith((".exe", ".msi")) or WINDOWS_WHEEL_RE.search(name):
+            return "win32"
+        if name_lower.endswith(".zip") and any(
+            marker in name_lower for marker in WINDOWS_ZIP_MARKERS
+        ):
+            return "win32"
+        if name_lower.endswith(SOURCE_SUFFIXES):
+            return "source"
+        return None
+
+    @staticmethod
+    def create_download(release, platform, asset):
+        location = asset.get("browser_download_url")
+        size = asset.get("size")
+        if not isinstance(location, str) or not location.startswith(
+            "https://github.com/gammu/",
+        ):
+            raise CommandError(f"Asset {asset['name']} has an invalid download URL.")
+        if not isinstance(size, int) or size < 0:
+            raise CommandError(f"Asset {asset['name']} has an invalid size.")
+
+        digest = asset.get("digest") or ""
+        if not isinstance(digest, str):
+            raise CommandError(f"Asset {asset['name']} has an invalid digest.")
+        sha256 = digest.removeprefix("sha256:") if digest.startswith("sha256:") else ""
+
+        Download.objects.create(
+            release=release,
+            platform=platform,
+            location=location,
+            sha256=sha256,
+            size=size,
+        )

--- a/downloads/migrations/0008_github_releases.py
+++ b/downloads/migrations/0008_github_releases.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+from django.utils import timezone
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("downloads", "0007_auto_20170614_1003"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="download",
+            name="location",
+            field=models.CharField(max_length=500),
+        ),
+        migrations.AlterField(
+            model_name="download",
+            name="md5",
+            field=models.CharField(blank=True, default="", max_length=250),
+        ),
+        migrations.AlterField(
+            model_name="download",
+            name="sha1",
+            field=models.CharField(blank=True, default="", max_length=250),
+        ),
+        migrations.AlterField(
+            model_name="download",
+            name="sha256",
+            field=models.CharField(blank=True, default="", max_length=250),
+        ),
+        migrations.AlterField(
+            model_name="release",
+            name="date",
+            field=models.DateTimeField(default=timezone.now),
+        ),
+        migrations.AddConstraint(
+            model_name="release",
+            constraint=models.UniqueConstraint(
+                fields=("program", "version"),
+                name="unique_program_version",
+            ),
+        ),
+    ]

--- a/downloads/models.py
+++ b/downloads/models.py
@@ -5,6 +5,7 @@ import markdown
 from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -86,10 +87,16 @@ class Release(models.Model):
     description_html = models.TextField(editable=False, blank=True)
     changelog = models.TextField(blank=True, null=True)
     changelog_html = models.TextField(blank=True, null=True, editable=False)
-    date = models.DateTimeField(auto_now_add=True)
+    date = models.DateTimeField(default=timezone.now)
     post_news = models.BooleanField(default=True)
 
     class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=("program", "version"),
+                name="unique_program_version",
+            ),
+        ]
         ordering = ["-date"]
 
     def __str__(self):
@@ -115,6 +122,7 @@ class Release(models.Model):
                 author=author,
                 excerpt=excerpt,
                 body=process_bug_links(body),
+                pub_date=self.date,
                 title=title,
                 slug=slug,
             )
@@ -150,10 +158,10 @@ class Release(models.Model):
 class Download(models.Model):
     release = models.ForeignKey(Release, on_delete=models.deletion.CASCADE)
     platform = models.CharField(max_length=100, choices=PLATFORM_CHOICES)
-    location = models.CharField(max_length=250)
-    md5 = models.CharField(max_length=250)
-    sha1 = models.CharField(max_length=250)
-    sha256 = models.CharField(max_length=250)
+    location = models.CharField(max_length=500)
+    md5 = models.CharField(max_length=250, blank=True, default="")
+    sha1 = models.CharField(max_length=250, blank=True, default="")
+    sha256 = models.CharField(max_length=250, blank=True, default="")
     size = models.IntegerField()
 
     class Meta:

--- a/downloads/templatetags/getlink.py
+++ b/downloads/templatetags/getlink.py
@@ -9,6 +9,8 @@ register = template.Library()
 
 @register.simple_tag
 def getlink(item):
+    if item.location.startswith("https://github.com/"):
+        return item.location
     return f"https://dl.cihar.com{item.location}"
 
 

--- a/downloads/tests.py
+++ b/downloads/tests.py
@@ -1,24 +1,377 @@
-"""
-This file demonstrates two different styles of tests (one doctest and one
-unittest). These will both pass when you run "manage.py test".
+import io
+import json
+from datetime import datetime
+from unittest.mock import patch
+from urllib.error import URLError
 
-Replace these with more appropriate tests for your application.
-"""
-
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.template.loader import render_to_string
 from django.test import TestCase
 
+from downloads.management.commands.sync_github_releases import (
+    SYNC_NAME,
+    SYNC_USERNAME,
+    Command,
+)
+from downloads.models import Download, Release
+from downloads.templatetags.getlink import getlink
+from news.models import Category, Entry
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """Tests that 1 + 1 always equals 2."""
-        self.assertEqual(1 + 1, 2)
+
+def github_release(
+    version="1.2.3",
+    *,
+    body="* Fixed an important bug.",
+    assets=None,
+    draft=False,
+    prerelease=False,
+):
+    if assets is None:
+        assets = []
+    return {
+        "tag_name": version,
+        "body": body,
+        "published_at": "2026-07-28T07:49:15Z",
+        "draft": draft,
+        "prerelease": prerelease,
+        "assets": assets,
+    }
 
 
-__test__ = {
-    "doctest": """
-Another way to test that 1 + 1 is equal to 2.
+def github_asset(name, *, digest="sha256:abc123", size=1024):
+    return {
+        "name": name,
+        "browser_download_url": (
+            f"https://github.com/gammu/gammu/releases/download/1.2.3/{name}"
+        ),
+        "digest": digest,
+        "size": size,
+    }
 
->>> 1 + 1 == 2
-True
-""",
-}
+
+class FakeResponse(io.BytesIO):
+    def __init__(self, payload, link=""):
+        super().__init__(json.dumps(payload).encode())
+        self.headers = {"Link": link}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+class SyncGitHubReleasesTest(TestCase):
+    def setUp(self):
+        for slug, title in (
+            ("gammu", "Gammu"),
+            ("python-gammu", "python-gammu"),
+            ("wammu", "Wammu"),
+        ):
+            Category.objects.create(
+                slug=slug,
+                title=title,
+                description=f"{title} news",
+            )
+
+    def run_sync(self, feeds):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        def fetch_releases(command, repository):
+            return feeds[repository]
+
+        with patch.object(Command, "fetch_releases", autospec=True) as fetch:
+            fetch.side_effect = fetch_releases
+            call_command(
+                "sync_github_releases",
+                stdout=stdout,
+                stderr=stderr,
+            )
+        return stdout.getvalue(), stderr.getvalue()
+
+    def test_imports_release_news_and_selected_assets(self):
+        source = github_asset("Gammu-1.2.3.tar.gz", size=2048)
+        installer = github_asset("Gammu-1.2.3-Windows.exe")
+        windows_wheel = github_asset("python_gammu-1.2.3-cp313-win_amd64.whl")
+        windows_zip = github_asset("Gammu-1.2.3-Windows.zip")
+        source_zip = github_asset("Gammu-1.2.3.zip")
+        linux_wheel = github_asset(
+            "python_gammu-1.2.3-cp313-manylinux_2_28_x86_64.whl",
+        )
+        signature = github_asset("Gammu-1.2.3.tar.gz.asc")
+        stdout, stderr = self.run_sync(
+            {
+                "gammu": [
+                    github_release(
+                        assets=[
+                            source,
+                            installer,
+                            windows_wheel,
+                            windows_zip,
+                            source_zip,
+                            linux_wheel,
+                            signature,
+                        ],
+                    ),
+                ],
+                "python-gammu": [],
+                "wammu": [],
+            },
+        )
+
+        release = Release.objects.get(program="gammu", version="1.2.3")
+        self.assertEqual(release.author.username, SYNC_USERNAME)
+        self.assertEqual(
+            release.date,
+            datetime.fromisoformat("2026-07-28T07:49:15+00:00"),
+        )
+        self.assertEqual(release.changelog, "* Fixed an important bug.")
+        self.assertEqual(
+            release.description,
+            "This release is available from GitHub.",
+        )
+        self.assertFalse(release.post_news)
+
+        sync_user = User.objects.get(username=SYNC_USERNAME)
+        self.assertFalse(sync_user.is_active)
+        self.assertFalse(sync_user.has_usable_password())
+        self.assertEqual(sync_user.get_full_name(), SYNC_NAME)
+        self.assertEqual(sync_user.email, settings.SERVER_EMAIL)
+
+        entry = Entry.objects.get(title="Gammu 1.2.3")
+        self.assertEqual(entry.author, sync_user)
+        self.assertEqual(entry.pub_date, release.date)
+        self.assertEqual(
+            list(entry.categories.values_list("slug", flat=True)),
+            ["gammu"],
+        )
+        self.assertIn("* Fixed an important bug.", entry.body)
+
+        downloads = list(release.download_set.order_by("location"))
+        self.assertEqual(len(downloads), 5)
+        self.assertEqual(
+            {download.platform for download in downloads},
+            {"source", "win32"},
+        )
+        self.assertEqual(
+            release.download_set.get(location=source["browser_download_url"]).sha256,
+            "abc123",
+        )
+        self.assertEqual(
+            release.download_set.get(location=source["browser_download_url"]).size,
+            2048,
+        )
+        self.assertEqual(
+            release.download_set.get(
+                location=windows_zip["browser_download_url"],
+            ).platform,
+            "win32",
+        )
+        self.assertEqual(
+            release.download_set.get(
+                location=source_zip["browser_download_url"],
+            ).platform,
+            "source",
+        )
+        self.assertIn("Created 1 releases and 5 downloads", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_skips_release_without_supported_downloads(self):
+        stdout, stderr = self.run_sync(
+            {
+                "gammu": [
+                    github_release(
+                        assets=[
+                            github_asset(
+                                "python_gammu-1.2.3-cp313-manylinux_2_28_x86_64.whl",
+                            ),
+                            github_asset("Gammu-1.2.3.tar.gz.asc"),
+                        ],
+                    ),
+                ],
+                "python-gammu": [],
+                "wammu": [],
+            },
+        )
+
+        self.assertFalse(Release.objects.exists())
+        self.assertFalse(Entry.objects.exists())
+        self.assertFalse(Download.objects.exists())
+        self.assertIn("Created 0 releases and 0 downloads; skipped 1 releases", stdout)
+        self.assertIn("no supported downloads", stderr)
+
+    def test_sync_user_backfills_missing_display_metadata(self):
+        sync_user = User.objects.create(username=SYNC_USERNAME, is_active=False)
+        sync_user.set_unusable_password()
+        sync_user.save(update_fields=["password"])
+
+        sync_user = Command.get_sync_user()
+
+        self.assertEqual(sync_user.get_full_name(), SYNC_NAME)
+        self.assertEqual(sync_user.email, settings.SERVER_EMAIL)
+        self.assertFalse(sync_user.has_usable_password())
+
+    def test_skips_drafts_prereleases_invalid_tags_and_existing_releases(self):
+        author = User.objects.create_user(username="maintainer")
+        Release.objects.create(
+            author=author,
+            program="gammu",
+            version="1.2.3",
+            description="Existing",
+            changelog="Existing",
+            post_news=False,
+        )
+
+        stdout, stderr = self.run_sync(
+            {
+                "gammu": [
+                    github_release(),
+                    github_release("1.2.4", draft=True),
+                    github_release("1.2.5", prerelease=True),
+                    github_release("v1.2.6"),
+                ],
+                "python-gammu": [],
+                "wammu": [],
+            },
+        )
+
+        self.assertEqual(Release.objects.count(), 1)
+        self.assertEqual(Entry.objects.count(), 0)
+        self.assertIn("skipped 4 releases", stdout)
+        self.assertIn("unsupported tag 'v1.2.6'", stderr)
+
+    def test_existing_release_is_not_refreshed(self):
+        initial = github_release(
+            body="Original notes",
+            assets=[github_asset("Gammu-1.2.3.tar.gz")],
+        )
+        self.run_sync(
+            {"gammu": [initial], "python-gammu": [], "wammu": []},
+        )
+
+        changed = github_release(
+            body="Changed notes",
+            assets=[
+                github_asset("Gammu-1.2.3.tar.gz"),
+                github_asset("Gammu-1.2.3-Windows.exe"),
+            ],
+        )
+        stdout, _stderr = self.run_sync(
+            {"gammu": [changed], "python-gammu": [], "wammu": []},
+        )
+
+        release = Release.objects.get()
+        self.assertEqual(release.changelog, "Original notes")
+        self.assertEqual(Download.objects.count(), 1)
+        self.assertEqual(Entry.objects.count(), 1)
+        self.assertIn("Created 0 releases and 0 downloads", stdout)
+
+    def test_malformed_release_rolls_back_all_imports(self):
+        malformed = github_release("2.0.0")
+        malformed["assets"] = None
+
+        with self.assertRaisesMessage(CommandError, "invalid assets"):
+            self.run_sync(
+                {
+                    "gammu": [github_release()],
+                    "python-gammu": [malformed],
+                    "wammu": [],
+                },
+            )
+
+        self.assertFalse(Release.objects.exists())
+        self.assertFalse(Entry.objects.exists())
+        self.assertFalse(User.objects.filter(username=SYNC_USERNAME).exists())
+
+
+class GitHubAPITest(TestCase):
+    @patch(
+        "downloads.management.commands.sync_github_releases.urlopen",
+    )
+    def test_fetches_paginated_releases(self, urlopen):
+        next_url = (
+            "https://api.github.com/repos/gammu/gammu/releases?per_page=100&page=2"
+        )
+        urlopen.side_effect = [
+            FakeResponse(
+                [github_release()],
+                f'<{next_url}>; rel="next", <{next_url}>; rel="last"',
+            ),
+            FakeResponse([github_release("1.2.2")]),
+        ]
+
+        releases = Command().fetch_releases("gammu")
+
+        self.assertEqual(
+            [release["tag_name"] for release in releases], ["1.2.3", "1.2.2"]
+        )
+        self.assertEqual(urlopen.call_count, 2)
+        request = urlopen.call_args_list[0].args[0]
+        self.assertEqual(request.get_header("User-agent"), "wammu.eu-release-sync")
+
+    @patch(
+        "downloads.management.commands.sync_github_releases.urlopen",
+        side_effect=URLError("offline"),
+    )
+    def test_api_failure_is_reported(self, urlopen):
+        with self.assertRaisesMessage(CommandError, "Could not fetch releases"):
+            Command().fetch_releases("gammu")
+        urlopen.assert_called_once()
+
+    @patch(
+        "downloads.management.commands.sync_github_releases.urlopen",
+        return_value=FakeResponse({"message": "rate limited"}),
+    )
+    def test_malformed_api_response_is_reported(self, urlopen):
+        with self.assertRaisesMessage(CommandError, "Unexpected releases response"):
+            Command().fetch_releases("gammu")
+        urlopen.assert_called_once()
+
+
+class DownloadRenderingTest(TestCase):
+    def test_getlink_preserves_github_and_legacy_locations(self):
+        github_download = Download(
+            location="https://github.com/gammu/gammu/releases/download/1.2.3/file.zip",
+        )
+        legacy_download = Download(location="/gammu/releases/file.zip")
+
+        self.assertEqual(getlink(github_download), github_download.location)
+        self.assertEqual(
+            getlink(legacy_download),
+            "https://dl.cihar.com/gammu/releases/file.zip",
+        )
+
+    def test_download_list_omits_empty_checksum(self):
+        author = User.objects.create_user(username="maintainer")
+        release = Release.objects.create(
+            author=author,
+            program="gammu",
+            version="1.2.3",
+            description="Release",
+            changelog="Changes",
+            post_news=False,
+        )
+        Download.objects.create(
+            release=release,
+            platform="source",
+            location=(
+                "https://github.com/gammu/gammu/releases/"
+                "download/1.2.3/Gammu-1.2.3.tar.gz"
+            ),
+            size=1024,
+        )
+
+        rendered = render_to_string(
+            "downloads/dllist.html",
+            {
+                "downloads": release.download_set.all(),
+                "program_name": "gammu",
+            },
+        )
+
+        self.assertNotIn('class="checksums"', rendered)
+        self.assertIn("https://github.com/gammu/gammu/releases/download/", rendered)

--- a/html/downloads/dllist.html
+++ b/html/downloads/dllist.html
@@ -8,7 +8,7 @@
 <ul>
 {% for item in download.list %}
 <li><a href="{% getlink item %}" class="piwik_download">{{ item.get_filename }}</a> ({{ item.get_size }})
-    <div class="checksums">{% if item.sha256 %}SHA256: <code>{{ item.sha256 }}</code>{% else %}SHA1: <code>{{ item.sha1 }}</code>{% endif %}</div></li>
+    {% if item.sha256 %}<div class="checksums">SHA256: <code>{{ item.sha256 }}</code></div>{% elif item.sha1 %}<div class="checksums">SHA1: <code>{{ item.sha1 }}</code></div>{% elif item.md5 %}<div class="checksums">MD5: <code>{{ item.md5 }}</code></div>{% endif %}</li>
 {% endfor %}
 </ul>
 


### PR DESCRIPTION
Release announcements and download metadata currently require manual website updates. Sync stable GitHub releases from cron so news and download pages stay current and serve upstream assets directly.